### PR TITLE
Add KUBE_NAMESPACE

### DIFF
--- a/templates/mongo/statefulset.yaml
+++ b/templates/mongo/statefulset.yaml
@@ -66,6 +66,8 @@ spec:
           value: "true"
         - name: MONGODB_DATABASE
           value: "admin"
+        - name: KUBE_NAMESPACE
+          value: "{{.namespace}}"
       - name: mongod
         image: {{.image}}
         args:


### PR DESCRIPTION
This is a bit more efficient as according to mongo-sidecar documentation: 
```
The namespace to look up pods in. Not setting it will search for pods in all namespaces.
```
Doc: https://github.com/cvallance/mongo-k8s-sidecar