### PR TITLE
Update Statefulset version

### DIFF
--- a/templates/mongo/statefulset.yaml
+++ b/templates/mongo/statefulset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: mongod


### PR DESCRIPTION
apps/v1beta1 is an old version. It has `UpdateStrategy: OnDelete` by default. We want `UpdateStrategy: RollingUpdate` that is the default behaviour (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates)

Otherwise, we cannot use commands like: `kubectl rollout status statefulset/mongod --namespace=mongodb` (We get error: OnDelete updateStrategy does not have a Status`)

And rollouts for mongo would be more manual